### PR TITLE
[libuser] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/rpm/libuser.spec
+++ b/rpm/libuser.spec
@@ -9,6 +9,7 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(popt)
+BuildRequires:  pkgconfig(libcrypt)
 BuildRequires:  pam-devel
 BuildRequires:  gettext-devel
 


### PR DESCRIPTION
libuser depdends on pkconfig(libcrypt) for the crypt import but it was
not included. This fails when pkconfig(libcrypt) is not bundled in the glib-devel package.
Also convert -devel requires to use pkgconfig.